### PR TITLE
Created a better example for seeding + output es5 instead of es6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install lcg
 ```js
 import {Random} from 'lcg';
 
-const seed = Math.random() * (1 << 32);
+const seed = Math.random() * (Math.pow(2, 31) - 2);
 
 const random = new Random(seed);
 const value = random.get();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "module": "commonjs",
-    "target": "es6",
+    "target": "es5",
     "noImplicitAny": true,
     "outDir": "out",
     "rootDir": "src",


### PR DESCRIPTION
This project kind of seems like a small pet project but I had a hell of a time trying to find a library where a random number generator could be made without state! Anyway, this pull request resolves some issues I had working with this library.

The README instructs to use (1 << 32) as the multiplier for the random number when in fact that evaluates to 1 and, thus, effectively, the seed will be 0 and the output of the first few numbers from the LCG will likely be 0.

Additionally, I had some trouble trying to integrate this into a react project [due to the minifier only working on es5](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify).